### PR TITLE
Fix event dashboard approval time

### DIFF
--- a/backend/api/api.py
+++ b/backend/api/api.py
@@ -1650,6 +1650,7 @@ def approve_registration(request, event_id: int, ticket_id: str):
             ticket = Ticket.objects.select_related('attendee', 'event').get(qr_code=ticket_id, event=event)
         
         ticket.approval_status = 'approved'
+        ticket.approved_at = timezone.now()
         ticket.save()
         
         # 🔔 Send notification

--- a/frontend/uniplus/lib/dashboard/useDashboard.ts
+++ b/frontend/uniplus/lib/dashboard/useDashboard.ts
@@ -224,6 +224,8 @@ export function useDashboard(eventId: string | undefined) {
   const approveReject = async (ticketId: string, action: ApprovalAction) => {
     if (!state.event) return;
 
+    const now = new Date().toISOString();
+
     setState((s) => ({
       ...s,
       attendees: s.attendees.map((a) =>
@@ -231,6 +233,8 @@ export function useDashboard(eventId: string | undefined) {
           ? {
               ...a,
               approvalStatus: action === "approve" ? "approved" : "rejected",
+              approvedAt: action === "approve" ? now : a.approvedAt,
+              rejectedAt: action === "reject" ? now : a.rejectedAt,
             }
           : a
       ),


### PR DESCRIPTION
### What's new

- Add timestamps for approve ticket endpoint (/events/{event_id}/registrations/{ticket_id}/approve)
- Add timestamps for approval action in useDashboard.ts 

### Functional Acceptance Criteria

- User can see the actual time when an approval action was made.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Testing
- [ ] Documentation update
- [ ] Other

### Additional Information

It would be good to try both status which are approve and reject.